### PR TITLE
Updates related to the Cobalt Strike 4.6 release

### DIFF
--- a/beacon.h
+++ b/beacon.h
@@ -4,6 +4,9 @@
  * A Beacon Object File is a light-weight post exploitation tool that runs
  * with Beacon's inline-execute command.
  *
+ * Additional BOF resources are available here:
+ *   - https://github.com/Cobalt-Strike/bof_template
+ *
  * Cobalt Strike 4.x
  * ChangeLog:
  *    1/25/2022: updated for 4.5

--- a/tests/src/testBeaconFormat.c
+++ b/tests/src/testBeaconFormat.c
@@ -23,26 +23,51 @@ void go(char * args, int alen) {
    BeaconFormatAlloc(&buffer, 1024);
 
    /* Build up a buffer of information */
-   BeaconFormatPrintf(&buffer, "Start of the formated buffer:\n");
+   BeaconFormatPrintf(&buffer, "BeaconFormat test with end of string (EOS) issue:\n");
    BeaconFormatPrintf(&buffer, "The user passed in the integer: %d\n", userInt); 
    BeaconFormatPrintf(&buffer, "The user passed in the string: ");
    BeaconFormatAppend(&buffer, userString, userStringLen);
-   BeaconFormatPrintf(&buffer, "\nAppending some test integer: ");
-   BeaconFormatInt(&buffer, 2022);
+   BeaconFormatPrintf(&buffer, "Do you see this string? No because the EOS was copied over as well.\n");
 
    /* Send the buffer of information with BeaconPrintf */
-   /* Note: BecaonFormatToString has a defect and requires the size parameter to be set */
-   BeaconPrintf(CALLBACK_OUTPUT, "%s\n", BeaconFormatToString(&buffer, &bufferStringLen));
+   BeaconPrintf(CALLBACK_OUTPUT, "%s\n", BeaconFormatToString(&buffer, NULL));
    
+
+   /* Reset and do the same thing again but resolve the EOS issue */
+   BeaconFormatReset(&buffer);
+   BeaconFormatPrintf(&buffer, "BeaconFormat test with end of string (EOS) issue resolved:\n");
+   BeaconFormatPrintf(&buffer, "The user passed in the integer: %d\n", userInt);
+   BeaconFormatPrintf(&buffer, "The user passed in the string: ");
+   BeaconFormatAppend(&buffer, userString, userStringLen - 1);
+   BeaconFormatPrintf(&buffer, "\nDo you see this string? Yes because the EOS was not copied.\n");
+
+   /* Send the buffer of information with BeaconPrintf */
+   BeaconPrintf(CALLBACK_OUTPUT, "%s\n", BeaconFormatToString(&buffer, NULL));
+
+
    /* Reset the buffer and format the information differently */
    BeaconFormatReset(&buffer);
-   BeaconFormatPrintf(&buffer, "Format buffer has been reset\n");
-   BeaconFormatPrintf(&buffer, "Input String (%d): %s Input Integer: %d\n", userStringLen, userString, userInt);
+   BeaconFormatPrintf(&buffer, "BeaconFormat test formating the information differently.\n");
+   BeaconFormatPrintf(&buffer, "Input String (%d): %s\nInput Integer: %d\n", userStringLen, userString, userInt);
    
    /* Send the buffer of information with BeaconOutput */
    bufferString = BeaconFormatToString(&buffer, &bufferStringLen);
    BeaconOutput(CALLBACK_OUTPUT, bufferString, bufferStringLen);
    
+
+   /* Reset the buffer and see how BeaconFormatInt works */
+   /* The BeaconFormatInt function is for internal use and is not useful for external BOFs */
+   BeaconFormatReset(&buffer);
+   BeaconFormatPrintf(&buffer, "BeaconFormat using BeaconFormatInt\n");
+   BeaconFormatPrintf(&buffer, "Appending 3 test integers: ");
+   BeaconFormatInt(&buffer, 65);  // ASCII - A
+   BeaconFormatInt(&buffer, 32);  // ASCII - SPACE
+   BeaconFormatInt(&buffer, 66);  // ASCII - B
+   BeaconFormatPrintf(&buffer, "\nDo you see this string? Yes because BeaconFormatInt does not add an EOS.\n");
+
+   /* Send the buffer of information with BeaconOutput */
+   bufferString = BeaconFormatToString(&buffer, &bufferStringLen);
+   BeaconOutput(CALLBACK_OUTPUT, bufferString, bufferStringLen);
 
    /* Cleanup */
    BeaconFormatFree(&buffer);


### PR DESCRIPTION
Made the following updates:

- Added a link to this repository in the beacon.h
- Updates to the testBeaconFormat.c file
- Show an example where BeaconFormatToString now accepts a NULL if the length of the string is not needed. Fixed in CS version 4.6
