### PR TITLE
Release 4.11

### DIFF
--- a/beacon.h
+++ b/beacon.h
@@ -22,6 +22,7 @@
  *    4/19/2024: Added BeaconGetSyscallInformation API for 4.10
  *    4/25/2024: Added APIs to call Beacon's system call implementation
  *    12/18/2024: Updated BeaconGetSyscallInformation API for 4.11 (Breaking changes)
+ *    2/13/2025: Updated SYSCALL_API structure with more ntAPIs
  */
 #ifndef _BEACON_H_
 #define _BEACON_H_

--- a/beacon.h
+++ b/beacon.h
@@ -302,22 +302,22 @@ typedef struct
 	SYSCALL_API_ENTRY ntReadFile;
 	SYSCALL_API_ENTRY ntWriteFile;
 	SYSCALL_API_ENTRY ntCreateFile;
-        SYSCALL_API_ENTRY ntQueueApcThread;
-        SYSCALL_API_ENTRY ntCreateProcess;
-        SYSCALL_API_ENTRY ntOpenProcessToken;
-        SYSCALL_API_ENTRY ntTestAlert;
-        SYSCALL_API_ENTRY ntSuspendProcess;
-        SYSCALL_API_ENTRY ntResumeProcess;
-        SYSCALL_API_ENTRY ntQuerySystemInformation;
-        SYSCALL_API_ENTRY ntQueryDirectoryFile;
-        SYSCALL_API_ENTRY ntSetInformationProcess;
-        SYSCALL_API_ENTRY ntSetInformationThread;
-        SYSCALL_API_ENTRY ntQueryInformationProcess;
-        SYSCALL_API_ENTRY ntQueryInformationThread;
-        SYSCALL_API_ENTRY ntOpenSection;
-        SYSCALL_API_ENTRY ntAdjustPrivilegesToken;
-        SYSCALL_API_ENTRY ntDeviceIoControlFile;
-        SYSCALL_API_ENTRY ntWaitForMultipleObjects;
+	SYSCALL_API_ENTRY ntQueueApcThread;
+	SYSCALL_API_ENTRY ntCreateProcess;
+	SYSCALL_API_ENTRY ntOpenProcessToken;
+	SYSCALL_API_ENTRY ntTestAlert;
+	SYSCALL_API_ENTRY ntSuspendProcess;
+	SYSCALL_API_ENTRY ntResumeProcess;
+	SYSCALL_API_ENTRY ntQuerySystemInformation;
+	SYSCALL_API_ENTRY ntQueryDirectoryFile;
+	SYSCALL_API_ENTRY ntSetInformationProcess;
+	SYSCALL_API_ENTRY ntSetInformationThread;
+	SYSCALL_API_ENTRY ntQueryInformationProcess;
+	SYSCALL_API_ENTRY ntQueryInformationThread;
+	SYSCALL_API_ENTRY ntOpenSection;
+	SYSCALL_API_ENTRY ntAdjustPrivilegesToken;
+	SYSCALL_API_ENTRY ntDeviceIoControlFile;
+	SYSCALL_API_ENTRY ntWaitForMultipleObjects;
 } SYSCALL_API, *PSYSCALL_API;
 
 /* Additional Run Time Library (RTL) addresses used to support system calls.
@@ -368,6 +368,9 @@ DECLSPEC_IMPORT BOOL BeaconWriteProcessMemory(HANDLE hProcess, LPVOID lpBaseAddr
 /* Beacon Gate APIs */
 DECLSPEC_IMPORT VOID BeaconDisableBeaconGate();
 DECLSPEC_IMPORT VOID BeaconEnableBeaconGate();
+
+DECLSPEC_IMPORT VOID BeaconDisableBeaconGateMasking();
+DECLSPEC_IMPORT VOID BeaconEnableBeaconGateMasking();
 
 /* Beacon User Data
  *

--- a/beacon.h
+++ b/beacon.h
@@ -301,6 +301,22 @@ typedef struct
 	SYSCALL_API_ENTRY ntReadFile;
 	SYSCALL_API_ENTRY ntWriteFile;
 	SYSCALL_API_ENTRY ntCreateFile;
+        SYSCALL_API_ENTRY ntQueueApcThread;
+        SYSCALL_API_ENTRY ntCreateProcess;
+        SYSCALL_API_ENTRY ntOpenProcessToken;
+        SYSCALL_API_ENTRY ntTestAlert;
+        SYSCALL_API_ENTRY ntSuspendProcess;
+        SYSCALL_API_ENTRY ntResumeProcess;
+        SYSCALL_API_ENTRY ntQuerySystemInformation;
+        SYSCALL_API_ENTRY ntQueryDirectoryFile;
+        SYSCALL_API_ENTRY ntSetInformationProcess;
+        SYSCALL_API_ENTRY ntSetInformationThread;
+        SYSCALL_API_ENTRY ntQueryInformationProcess;
+        SYSCALL_API_ENTRY ntQueryInformationThread;
+        SYSCALL_API_ENTRY ntOpenSection;
+        SYSCALL_API_ENTRY ntAdjustPrivilegesToken;
+        SYSCALL_API_ENTRY ntDeviceIoControlFile;
+        SYSCALL_API_ENTRY ntWaitForMultipleObjects;
 } SYSCALL_API, *PSYSCALL_API;
 
 /* Additional Run Time Library (RTL) addresses used to support system calls.

--- a/beacon.h
+++ b/beacon.h
@@ -21,6 +21,7 @@
  *               Updated the BEACON_INFO data structure to add new parameters
  *    4/19/2024: Added BeaconGetSyscallInformation API for 4.10
  *    4/25/2024: Added APIs to call Beacon's system call implementation
+ *    12/18/2024: Updated BeaconGetSyscallInformation API for 4.11 (Breaking changes)
  */
 #ifndef _BEACON_H_
 #define _BEACON_H_
@@ -316,13 +317,18 @@ typedef struct
 	PVOID rtlGetProcessHeapAddr;
 } RTL_API, *PRTL_API;
 
+/* Updated in version 4.11 to use the entire structure instead of pointers to the structure.
+ * This allows for retrieving a copy of the information which would be under the BOF's
+ * control instead of a reference pointer which may be obfuscated when beacon is sleeping.
+ */
 typedef struct
 {
-	PSYSCALL_API syscalls;
-	PRTL_API     rtls;
+	SYSCALL_API syscalls;
+	RTL_API     rtls;
 } BEACON_SYSCALLS, *PBEACON_SYSCALLS;
 
-DECLSPEC_IMPORT BOOL BeaconGetSyscallInformation(PBEACON_SYSCALLS info, BOOL resolveIfNotInitialized);
+/* Updated in version 4.11 to include the size of the info pointer, which equals sizeof(BEACON_SYSCALLS) */
+DECLSPEC_IMPORT BOOL BeaconGetSyscallInformation(PBEACON_SYSCALLS info, SIZE_T infoSize, BOOL resolveIfNotInitialized);
 
 /* Beacon System call functions which will use the current system call method */
 DECLSPEC_IMPORT LPVOID BeaconVirtualAlloc(LPVOID lpAddress, SIZE_T dwSize, DWORD flAllocationType, DWORD flProtect);

--- a/examples/cs_beacon_syscalls/cs_beacon_syscalls_info.c
+++ b/examples/cs_beacon_syscalls/cs_beacon_syscalls_info.c
@@ -20,46 +20,45 @@ void dump_syscalls(formatp * buffer, PBEACON_SYSCALLS info) {
    }
    
    BeaconFormatPrintf(buffer, "System Calls:\n");
-   dump_api_entry(buffer, "ntAllocateVirtualMemory", &info->syscalls->ntAllocateVirtualMemory);
-   dump_api_entry(buffer, "ntProtectVirtualMemory", &info->syscalls->ntProtectVirtualMemory);
-   dump_api_entry(buffer, "ntFreeVirtualMemory", &info->syscalls->ntFreeVirtualMemory);
-   dump_api_entry(buffer, "ntGetContextThread", &info->syscalls->ntGetContextThread);
-   dump_api_entry(buffer, "ntSetContextThread", &info->syscalls->ntSetContextThread);
-   dump_api_entry(buffer, "ntResumeThread", &info->syscalls->ntResumeThread);
-   dump_api_entry(buffer, "ntCreateThreadEx", &info->syscalls->ntCreateThreadEx);
-   dump_api_entry(buffer, "ntOpenProcess", &info->syscalls->ntOpenProcess);
-   dump_api_entry(buffer, "ntOpenThread", &info->syscalls->ntOpenThread);
-   dump_api_entry(buffer, "ntClose", &info->syscalls->ntClose);
-   dump_api_entry(buffer, "ntCreateSection", &info->syscalls->ntCreateSection);
-   dump_api_entry(buffer, "ntMapViewOfSection", &info->syscalls->ntMapViewOfSection);
-   dump_api_entry(buffer, "ntUnmapViewOfSection", &info->syscalls->ntUnmapViewOfSection);
-   dump_api_entry(buffer, "ntQueryVirtualMemory", &info->syscalls->ntQueryVirtualMemory);
-   dump_api_entry(buffer, "ntDuplicateObject", &info->syscalls->ntDuplicateObject);
-   dump_api_entry(buffer, "ntReadVirtualMemory", &info->syscalls->ntReadVirtualMemory);
-   dump_api_entry(buffer, "ntWriteVirtualMemory", &info->syscalls->ntWriteVirtualMemory);
-   dump_api_entry(buffer, "ntReadFile", &info->syscalls->ntReadFile);
-   dump_api_entry(buffer, "ntWriteFile", &info->syscalls->ntWriteFile);
-   dump_api_entry(buffer, "ntCreateFile", &info->syscalls->ntCreateFile);
+   dump_api_entry(buffer, "ntAllocateVirtualMemory", &info->syscalls.ntAllocateVirtualMemory);
+   dump_api_entry(buffer, "ntProtectVirtualMemory", &info->syscalls.ntProtectVirtualMemory);
+   dump_api_entry(buffer, "ntFreeVirtualMemory", &info->syscalls.ntFreeVirtualMemory);
+   dump_api_entry(buffer, "ntGetContextThread", &info->syscalls.ntGetContextThread);
+   dump_api_entry(buffer, "ntSetContextThread", &info->syscalls.ntSetContextThread);
+   dump_api_entry(buffer, "ntResumeThread", &info->syscalls.ntResumeThread);
+   dump_api_entry(buffer, "ntCreateThreadEx", &info->syscalls.ntCreateThreadEx);
+   dump_api_entry(buffer, "ntOpenProcess", &info->syscalls.ntOpenProcess);
+   dump_api_entry(buffer, "ntOpenThread", &info->syscalls.ntOpenThread);
+   dump_api_entry(buffer, "ntClose", &info->syscalls.ntClose);
+   dump_api_entry(buffer, "ntCreateSection", &info->syscalls.ntCreateSection);
+   dump_api_entry(buffer, "ntMapViewOfSection", &info->syscalls.ntMapViewOfSection);
+   dump_api_entry(buffer, "ntUnmapViewOfSection", &info->syscalls.ntUnmapViewOfSection);
+   dump_api_entry(buffer, "ntQueryVirtualMemory", &info->syscalls.ntQueryVirtualMemory);
+   dump_api_entry(buffer, "ntDuplicateObject", &info->syscalls.ntDuplicateObject);
+   dump_api_entry(buffer, "ntReadVirtualMemory", &info->syscalls.ntReadVirtualMemory);
+   dump_api_entry(buffer, "ntWriteVirtualMemory", &info->syscalls.ntWriteVirtualMemory);
+   dump_api_entry(buffer, "ntReadFile", &info->syscalls.ntReadFile);
+   dump_api_entry(buffer, "ntWriteFile", &info->syscalls.ntWriteFile);
+   dump_api_entry(buffer, "ntCreateFile", &info->syscalls.ntCreateFile);
 
    BeaconFormatPrintf(buffer, "\nRun Time Library Functions:\n");
-   dump_rtl_entry(buffer, "rtlDosPathNameToNtPathNameUWithStatusAddr", info->rtls->rtlDosPathNameToNtPathNameUWithStatusAddr);
-   dump_rtl_entry(buffer, "rtlFreeHeapAddr", info->rtls->rtlFreeHeapAddr);
-   dump_rtl_entry(buffer, "rtlGetProcessHeapAddr", info->rtls->rtlGetProcessHeapAddr);
+   dump_rtl_entry(buffer, "rtlDosPathNameToNtPathNameUWithStatusAddr", info->rtls.rtlDosPathNameToNtPathNameUWithStatusAddr);
+   dump_rtl_entry(buffer, "rtlFreeHeapAddr", info->rtls.rtlFreeHeapAddr);
+   dump_rtl_entry(buffer, "rtlGetProcessHeapAddr", info->rtls.rtlGetProcessHeapAddr);
 }
 
 /* entry point */
 void go(char * args, int alen) {
    formatp buffer;
    int size = 0;
-   BEACON_SYSCALLS info;
+   BEACON_SYSCALLS info = {0};
    BOOL status;
-
 
    /* Allocate space for formatted output buffer */
    BeaconFormatAlloc(&buffer, 8 * 1024);
 
    /* Generate the output */
-   status = BeaconGetSyscallInformation(&info, TRUE);
+   status = BeaconGetSyscallInformation(&info, sizeof(BEACON_SYSCALLS), TRUE);
    if (status) {
       dump_syscalls(&buffer, &info);
    } else {

--- a/examples/cs_beacon_syscalls/cs_beacon_syscalls_info.c
+++ b/examples/cs_beacon_syscalls/cs_beacon_syscalls_info.c
@@ -40,6 +40,22 @@ void dump_syscalls(formatp * buffer, PBEACON_SYSCALLS info) {
    dump_api_entry(buffer, "ntReadFile", &info->syscalls.ntReadFile);
    dump_api_entry(buffer, "ntWriteFile", &info->syscalls.ntWriteFile);
    dump_api_entry(buffer, "ntCreateFile", &info->syscalls.ntCreateFile);
+   dump_api_entry(buffer, "ntQueueApcThread", &info->syscalls.ntQueueApcThread);
+   dump_api_entry(buffer, "ntCreateProcess", &info->syscalls.ntCreateProcess);
+   dump_api_entry(buffer, "ntOpenProcessToken", &info->syscalls.ntOpenProcessToken);
+   dump_api_entry(buffer, "ntTestAlert", &info->syscalls.ntTestAlert);
+   dump_api_entry(buffer, "ntSuspendProcess", &info->syscalls.ntSuspendProcess);
+   dump_api_entry(buffer, "ntResumeProcess", &info->syscalls.ntResumeProcess);
+   dump_api_entry(buffer, "ntQuerySystemInformation", &info->syscalls.ntQuerySystemInformation);
+   dump_api_entry(buffer, "ntQueryDirectoryFile", &info->syscalls.ntQueryDirectoryFile);
+   dump_api_entry(buffer, "ntSetInformationProcess", &info->syscalls.ntSetInformationProcess);
+   dump_api_entry(buffer, "ntSetInformationThread", &info->syscalls.ntSetInformationThread);
+   dump_api_entry(buffer, "ntQueryInformationProcess", &info->syscalls.ntQueryInformationProcess);
+   dump_api_entry(buffer, "ntQueryInformationThread", &info->syscalls.ntQueryInformationThread);
+   dump_api_entry(buffer, "ntOpenSection", &info->syscalls.ntOpenSection);
+   dump_api_entry(buffer, "ntAdjustPrivilegesToken", &info->syscalls.ntAdjustPrivilegesToken);
+   dump_api_entry(buffer, "ntDeviceIoControlFile", &info->syscalls.ntDeviceIoControlFile);
+   dump_api_entry(buffer, "ntWaitForMultipleObjects", &info->syscalls.ntWaitForMultipleObjects);
 
    BeaconFormatPrintf(buffer, "\nRun Time Library Functions:\n");
    dump_rtl_entry(buffer, "rtlDosPathNameToNtPathNameUWithStatusAddr", info->rtls.rtlDosPathNameToNtPathNameUWithStatusAddr);


### PR DESCRIPTION
Supports Cobalt Strike release 4.11

-Updated beacon.h
-Updated the cs_beacon_syscalls_info example to include the additional system calls that are now resolved.
-Updated the cs_beacon_syscalls_info example to update the BeaconGetSyscallInformation API which has a breaking change.